### PR TITLE
Export value of net.netfilter.nf_conntrack_max

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -4,7 +4,7 @@ on:
     tags:
       - v*
     branches:
-      - main
+      - master
   pull_request:
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,13 +3,13 @@ name: Push to Registry
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
     tags:
       - '*'
 
 jobs:
   docker:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
     name: Push Docker Image
     runs-on: ubuntu-20.04
     steps:
@@ -30,9 +30,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            jwkohnen/conntrack-stats-exporter
+            travelping/conntrack-stats-exporter
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
             type=ref,event=tag
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,9 +47,37 @@ linters-settings:
   lll:
     line-length: 120
   depguard:
-    list-type: denylist
-    packages:
-      - github.com/sirupsen/logrus
+    rules:
+      main:
+        allow:
+          - "bytes"
+          - "context"
+          - "embed"
+          - "errors"
+          - "flag"
+          - "fmt"
+          - "github.com/containernetworking/plugins/pkg/utils/sysctl"
+          - "github.com/jwkohnen/conntrack-stats-exporter/exporter"
+          - "github.com/vishvananda/netns"
+          - "io"
+          - "log"
+          - "net/http"
+          - "os"
+          - "os/exec"
+          - "os/signal"
+          - "path"
+          - "regexp"
+          - "runtime"
+          - "sort"
+          - "strconv"
+          - "strings"
+          - "sync"
+          - "syscall"
+          - "testing"
+          - "text"
+          - "text/template"
+          - "time"
+
   funlen:
     lines: 110
     statements: 50

--- a/exporter/internal/exposition.go
+++ b/exporter/internal/exposition.go
@@ -162,6 +162,7 @@ var _help = map[string]string{
 	"search_restart": "Total of conntrack search_restart",
 	"count":          "Total of conntrack count",
 	"scrape_error":   "Total of error when calling/parsing conntrack command",
+	"max":            "Maximum of conntrack count",
 }
 
 type countWriter struct {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/jwkohnen/conntrack-stats-exporter
 
 go 1.18
 
-require github.com/vishvananda/netns v0.0.4
+require (
+	github.com/containernetworking/plugins v1.3.0
+	github.com/vishvananda/netns v0.0.4
+)
 
-require golang.org/x/sys v0.6.0 // indirect
+require golang.org/x/sys v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/containernetworking/plugins v1.3.0 h1:QVNXMT6XloyMUoO2wUOqWTC1hWFV62Q6mVDp5H1HnjM=
+github.com/containernetworking/plugins v1.3.0/go.mod h1:Pc2wcedTQQCVuROOOaLBPPxrEXqqXBFt3cZ+/yVg6l0=
 github.com/vishvananda/netns v0.0.0-20220913150850-18c4f4234207 h1:nn7SOQy8xCu3iXNv7oiBhhEQtbWdnEOMnuKBlHvrqIM=
 github.com/vishvananda/netns v0.0.0-20220913150850-18c4f4234207/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
@@ -9,3 +11,5 @@ golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Adds a new metric `conntrack_stats_max` that contains the value of `net.netfilter.nf_conntrack_max`.

We can use this to create better alerts that are based on the used percentage of the maximum number of conntrack entries.